### PR TITLE
Feat/remove error code and endpoint enum

### DIFF
--- a/proto/reach.proto
+++ b/proto/reach.proto
@@ -219,7 +219,9 @@ message DeviceInfoResponse {
   uint32 services                 = 8;    ///< A bit mask, allowing support for up to 32 services
   uint32 parameter_metadata_hash  = 9;    ///< Used to avoid reloading the parameter descriptions
   optional bytes application_identifier = 10;   ///< A UUID to find a custom user interface
-  uint32 endpoints                      = 11;   ///< A bit mask, non-zero if the device supports more than one endpoint.
+  uint32 endpoints                      = 11;   ///< A bit mask, non-zero if the device supports more than one endpoint (the first endpoint being this device).
+                                                ///  Endpoint id is defined by the bit position. The 1st bit (index 0) represents Endpoint id 1, 2nd bit (index 1) for id 2, and so on.
+                                                ///  Endpoint id may be used in passing information to/from devices other devices known by this device.
   bytes sizes_struct = 20;  ///< A packed structure informing the client of the size limitations of the server. See SizesOffsets for descriptions.
 }
 
@@ -233,15 +235,6 @@ enum ServiceIds {
   CLI             = 16; ///< Set this bit when the device supports the command line interface
   TIME            = 32; ///< Set this bit when the device supports the time service
   WIFI            = 64; ///< Set this bit when the device supports the WiFi service
-}
-
-/// binary bit masks or'ed together into the DeviceInfoResponse.endpoints
-enum EndpointIds { 
-  NO_ENDPOINTS    = 0;  ///< No other endpoints
-  ONE             = 1;  ///< This is the first of multiple endpoints.
-  TWO             = 2;  ///< This is the second of multiple endpoints. 
-  THREE           = 4;  ///< This is the third of multiple endpoints.
-  FOUR            = 8;  ///< This is the fourth of multiple endpoints.
 }
 
 /// 
@@ -726,7 +719,7 @@ enum ErrorCodes {
     WRITE_FAILED       = 3;  ///< The write failed.
     NOT_IMPLEMENTED    = 4;  ///< returned by weak implementations
     RESERVED_1         = 5;  ///< not yet used
-    COMPLETE           = 6;  ///< The operation is complete.
+    RESERVED_2         = 6;  ///< not yet used
     PERMISSION_DENIED  = 7;  ///< access not allowed
     BUFFER_TOO_SMALL   = 8;  ///< Requested a size larger than the buffer.
     INVALID_PARAMETER  = 9;  ///< Some function parameter is out of range

--- a/proto/reach.proto
+++ b/proto/reach.proto
@@ -726,7 +726,7 @@ enum ErrorCodes {
     WRITE_FAILED       = 3;  ///< The write failed.
     NOT_IMPLEMENTED    = 4;  ///< returned by weak implementations
     RESERVED_1         = 5;  ///< not yet used
-    RESERVED_2         = 6;  ///< not yet used
+    COMPLETE           = 6;  ///< The operation is complete.
     PERMISSION_DENIED  = 7;  ///< access not allowed
     BUFFER_TOO_SMALL   = 8;  ///< Requested a size larger than the buffer.
     INVALID_PARAMETER  = 9;  ///< Some function parameter is out of range

--- a/proto/reach.proto
+++ b/proto/reach.proto
@@ -219,9 +219,8 @@ message DeviceInfoResponse {
   uint32 services                 = 8;    ///< A bit mask, allowing support for up to 32 services
   uint32 parameter_metadata_hash  = 9;    ///< Used to avoid reloading the parameter descriptions
   optional bytes application_identifier = 10;   ///< A UUID to find a custom user interface
-  uint32 endpoints                      = 11;   ///< A bit mask, non-zero if the device supports more than one endpoint (the first endpoint being this device).
-                                                ///  Endpoint id is defined by the bit position. The 1st bit (index 0) represents Endpoint id 1, 2nd bit (index 1) for id 2, and so on.
-                                                ///  Endpoint id may be used in passing information to/from devices other devices known by this device.
+  uint32 endpoints                      = 11;   ///< A bit mask, non-zero if the device supports additional endpoints beyond itself.
+                                                ///  The bit position of non-zero bits describes the ID of the endpoint within the device.
   bytes sizes_struct = 20;  ///< A packed structure informing the client of the size limitations of the server. See SizesOffsets for descriptions.
 }
 


### PR DESCRIPTION
### Summary
- roll back previous change to error code "COMPLETE"
- remove enum for EndpointIds

### Details
The "COMPLETE" error code cause (at least) the Kotlin script to fail due to COMPLETE being already defined under FileTransferState. The error message states that enum names are unique under the same namespace rather than each enum definition.

Removing enum `EndpointIds` is based on the fact that, currently, this Enum has no other meaning than the bit position defined under `DeviceInfoResponse.Endpoints` i.e. that field self-enumerates the id as is. Also, `EndpointIds` enum only define 4 items, whereas the `DeviceInfoResponse.Endpoints` is UInt32. This becomes cumbersome for something that is self-described.

### Testing
I was able to compile this protobuf in Kotlin using existing script and make Android build. I suggest reviewers also try compiling this build for their platform e.g. firmware C, Web.